### PR TITLE
Allow connecting using settings.rootPrivateKey

### DIFF
--- a/makenode.js
+++ b/makenode.js
@@ -657,7 +657,12 @@ var installIpk = function(conn, ipkPath, callback) {
 
 };
 
-var configureNode = function(ip, port, password, callback) {
+/**
+ * SSH to a host and configure it to be a sudomesh node
+ * @param {String|undefined} password - password to SSH with
+ * @param {String|undefined} privateKey - ssh private key as a string (e.g. contents of ~/.ssh/id_rsa.pub)
+ */
+var configureNode = function(ip, port, password, privateKey, callback) {
 
     if(argv.ipkOnly && argv.hwInfo) {
         console.log("Not connecting to device at all since both --ipkOnly and --hwInfo specified");
@@ -691,7 +696,8 @@ var configureNode = function(ip, port, password, callback) {
             host: ip,
             port: port,
             username: 'root',
-            password: password
+            password: password,
+            privateKey: privateKey
         });
 };
 
@@ -732,9 +738,9 @@ function configure() {
 
         var ip = argv.ip || settings.ip || '192.168.1.1';
         var port = argv.port || settings.port || 22;
-        var password = argv.password || settings.rootPassword || 'meshtheplanet';
-
-        configureNode(ip, port, password, function(err) {
+        var password = argv.password || settings.rootPassword;
+        var privateKey = settings.rootPrivateKey
+        configureNode(ip, port, password, privateKey, function(err) {
             if(err) {
                 console.error("Error: " + err);
                 return;

--- a/settings.js.example
+++ b/settings.js.example
@@ -11,6 +11,9 @@ module.exports = {
     // The root password for the newly configured routers
     rootPassword: 'meshtheplanet',
 
+    // Private key to use to ssh as root
+    // rootPrivateKey: require('fs').readFileSync(require('path').join(process.env.HOME, '/.ssh/id_rsa')).toString(),
+
     // Clean templateStageDir and stageDir before running makenode
     cleanStaging: true,
 


### PR DESCRIPTION
Users can now use settings.rootPrivateKey to connect to a node using keypairs. This is an alternative to rootPassword.