### PR TITLE
turn logs back on (leave config related to remote logging out)

### DIFF
--- a/configs/templates/files/etc/config/system
+++ b/configs/templates/files/etc/config/system
@@ -1,3 +1,6 @@
 config system
   option hostname <%= host_name %>
   option timezone PST8PDT,M3.2.0,M11.1.0
+
+  option log_size 500
+  option log_file /var/log/messages


### PR DESCRIPTION
fixes bug introduced by https://github.com/sudomesh/makenode/commit/13fd952aa70cc1bf31017b2781c6b929fdf072c3

cc @paidforby 